### PR TITLE
lib/wasi-cli: add submodule for wasi:cli WIT definitions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,3 +39,6 @@
 	path = src/net
 	url = https://github.com/tinygo-org/net.git
 	branch = dev
+[submodule "lib/wasi-cli"]
+	path = lib/wasi-cli
+	url = https://github.com/WebAssembly/wasi-cli


### PR DESCRIPTION
This enables building WASI components with this command (assuming `wasm-tools` is installed):

```sh
wasm-tools component embed -w wasi:cli/command $(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ module.wasm -o embedded.wasm
```

Which is part of these 3 commands necessary to compile, embed, and componentize a Go program into a WebAssembly component:

```sh
tinygo build -target=wasip2 -o module.wasm ./cmd/some-program
wasm-tools component embed -w wasi:cli/command $(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ module.wasm -o embedded.wasm
wasm-tools component new embedded.wasm -o component.wasm
```
