### PR TITLE
all: use generated Go bindings

### DIFF
--- a/src/runtime/runtime_tinygowasmp2.go
+++ b/src/runtime/runtime_tinygowasmp2.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ydnar/wasm-tools-go/cm"
 	"github.com/ydnar/wasm-tools-go/wasi/cli/exit"
 	"github.com/ydnar/wasm-tools-go/wasi/cli/stdout"
-	"github.com/ydnar/wasm-tools-go/wasi/clocks/monotonicclock"
-	"github.com/ydnar/wasm-tools-go/wasi/clocks/wallclock"
+	monotonicclock "github.com/ydnar/wasm-tools-go/wasi/clocks/monotonic-clock"
+	wallclock "github.com/ydnar/wasm-tools-go/wasi/clocks/wall-clock"
 	"github.com/ydnar/wasm-tools-go/wasi/random/random"
 )
 

--- a/src/runtime/runtime_wasm_wasip2.go
+++ b/src/runtime/runtime_wasm_wasip2.go
@@ -6,8 +6,8 @@ import (
 	"unsafe"
 
 	"github.com/ydnar/wasm-tools-go/wasi/cli/environment"
-	"github.com/ydnar/wasm-tools-go/wasi/clocks/monotonicclock"
-	"github.com/ydnar/wasm-tools-go/wasi/clocks/wallclock"
+	monotonicclock "github.com/ydnar/wasm-tools-go/wasi/clocks/monotonic-clock"
+	wallclock "github.com/ydnar/wasm-tools-go/wasi/clocks/wall-clock"
 )
 
 type timeUnit int64

--- a/src/syscall/env_wasip2.go
+++ b/src/syscall/env_wasip2.go
@@ -9,7 +9,7 @@ import (
 func Environ() []string {
 	var env []string
 	for _, kv := range environment.GetEnvironment().Slice() {
-		env = append(env, kv.V0+"="+kv.V1)
+		env = append(env, kv[0]+"="+kv[1])
 	}
 	return env
 }

--- a/src/syscall/libc_wasip2.go
+++ b/src/syscall/libc_wasip2.go
@@ -12,9 +12,10 @@ import (
 	"github.com/ydnar/wasm-tools-go/wasi/cli/stderr"
 	"github.com/ydnar/wasm-tools-go/wasi/cli/stdin"
 	"github.com/ydnar/wasm-tools-go/wasi/cli/stdout"
-	"github.com/ydnar/wasm-tools-go/wasi/clocks/wallclock"
+	wallclock "github.com/ydnar/wasm-tools-go/wasi/clocks/wall-clock"
 	"github.com/ydnar/wasm-tools-go/wasi/filesystem/preopens"
 	"github.com/ydnar/wasm-tools-go/wasi/filesystem/types"
+	ioerror "github.com/ydnar/wasm-tools-go/wasi/io/error"
 	"github.com/ydnar/wasm-tools-go/wasi/io/streams"
 )
 
@@ -121,7 +122,7 @@ func findFreeFD() int32 {
 	return newfd
 }
 
-var wasiErrno error
+var wasiErrno ioerror.Error
 
 type wasiStream struct {
 	in  *streams.InputStream
@@ -696,7 +697,7 @@ func errorCodeToErrno(err types.ErrorCode) Errno {
 		return EINTR
 	case types.ErrorCodeInvalid:
 		return EINVAL
-	case types.ErrorCodeIo:
+	case types.ErrorCodeIO:
 		return EIO
 	case types.ErrorCodeIsDirectory:
 		return EISDIR


### PR DESCRIPTION
This PR changes the type of `wasiErrno`, which looked OK given nothing (yet) consumes that value.

However, I think the right thing to do is read the string value and immediately `ResourceDrop` it.