### PR TITLE
test: some additions for testing wasip2

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -433,6 +433,10 @@ tinygo-test-wasi-fast:
 	$(TINYGO) test -target wasi $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-test-wasip1-fast:
 	GOOS=wasip1 GOARCH=wasm $(TINYGO) test $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
+tinygo-test-wasip2-wip:
+	$(TINYGO) test -target wasip2 -wit-package $$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ -wit-world wasi:cli/command -x $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
+tinygo-test-wasip2-dev:
+	$(TINYGO) test -target wasip2 -wit-package $$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ -wit-world wasi:cli/command -x -work encoding/csv
 tinygo-bench-wasi:
 	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW)
 tinygo-bench-wasi-fast:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -434,7 +434,7 @@ tinygo-test-wasi-fast:
 tinygo-test-wasip1-fast:
 	GOOS=wasip1 GOARCH=wasm $(TINYGO) test $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-test-wasip2-wip:
-	$(TINYGO) test -target wasip2 -wit-package $$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ -wit-world wasi:cli/command -x $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
+	$(TINYGO) test -target wasip2 -x $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-test-wasip2-dev:
 	$(TINYGO) test -target wasip2 -wit-package $$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ -wit-world wasi:cli/command -x -work encoding/csv
 tinygo-bench-wasi:

--- a/builder/build.go
+++ b/builder/build.go
@@ -824,13 +824,84 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					"--output", result.Executable,
 				)
 
-				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
+				wasmopt := goenv.Get("WASMOPT")
+				if config.Options.PrintCommands != nil {
+					config.Options.PrintCommands(wasmopt, args...)
+				}
+				cmd := exec.Command(wasmopt, args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 
 				err := cmd.Run()
 				if err != nil {
 					return fmt.Errorf("wasm-opt failed: %w", err)
+				}
+			}
+
+			// Run wasm-tools for component-model binaries
+			hasWitOptions := config.Options.WitPackage != "" && config.Options.WitWorld != ""
+			if config.Options.Target == "wasip2" && hasWitOptions {
+
+				// wasm-tools component embed -w wasi:cli/command
+				// 		$$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ main.wasm -o embedded.wasm
+				args := []string{
+					"component",
+					"embed",
+					"-w", config.Options.WitWorld,
+					config.Options.WitPackage,
+					result.Executable,
+					"-o", result.Executable,
+				}
+
+				wasmtools := goenv.Get("WASMTOOLS")
+				if config.Options.PrintCommands != nil {
+					config.Options.PrintCommands(wasmtools, args...)
+				}
+				cmd := exec.Command(wasmtools, args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				err := cmd.Run()
+				if err != nil {
+					// Preserve a copy of the failure if -work option is used
+					if config.Options.Work {
+						dest := filepath.Join(
+							filepath.Dir(result.Executable),
+							fmt.Sprintf("%s.embed-fail.wasm", strings.Replace(pkgName, "/", "_", -1)),
+						)
+						copyCmd := exec.Command("cp", "-f", result.Executable, dest)
+						copyCmd.Run()
+					}
+					return fmt.Errorf("wasm-tools failed: %w", err)
+				}
+
+				// wasm-tools component new embedded.wasm -o component.wasm
+				args = []string{
+					"component",
+					"new",
+					result.Executable,
+					"-o", result.Executable,
+				}
+
+				if config.Options.PrintCommands != nil {
+					config.Options.PrintCommands(wasmtools, args...)
+				}
+				cmd = exec.Command(wasmtools, args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				err = cmd.Run()
+				if err != nil {
+					// Preserve a copy of the failure if -work option is used
+					if config.Options.Work {
+						dest := filepath.Join(
+							filepath.Dir(result.Executable),
+							fmt.Sprintf("%s.comp-fail.wasm", strings.Replace(pkgName, "/", "_", -1)),
+						)
+						copyCmd := exec.Command("cp", "-f", result.Executable, dest)
+						copyCmd.Run()
+					}
+					return fmt.Errorf("wasm-tools failed: %w", err)
 				}
 			}
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -839,16 +839,23 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 			}
 
 			// Run wasm-tools for component-model binaries
-			hasWitOptions := config.Options.WitPackage != "" && config.Options.WitWorld != ""
-			if config.Options.Target == "wasip2" && hasWitOptions {
+			witPackage := strings.ReplaceAll(config.Target.WitPackage, "{root}", goenv.Get("TINYGOROOT"))
+			if config.Options.WitPackage != "" {
+				witPackage = config.Options.WitPackage
+			}
+			witWorld := config.Target.WitWorld
+			if config.Options.WitWorld != "" {
+				witWorld = config.Options.WitWorld
+			}
+			if witPackage != "" && witWorld != "" {
 
 				// wasm-tools component embed -w wasi:cli/command
 				// 		$$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ main.wasm -o embedded.wasm
 				args := []string{
 					"component",
 					"embed",
-					"-w", config.Options.WitWorld,
-					config.Options.WitPackage,
+					"-w", witWorld,
+					witPackage,
 					result.Executable,
 					"-o", result.Executable,
 				}

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -53,6 +53,8 @@ type Options struct {
 	Monitor         bool
 	BaudRate        int
 	Timeout         time.Duration
+	WitPackage      string // pass through to wasm-tools component embed invocation
+	WitWorld        string // pass through to wasm-tools component embed -w option
 }
 
 // Verify performs a validation on the given options, raising an error if options are not valid.

--- a/compileopts/target.go
+++ b/compileopts/target.go
@@ -62,6 +62,8 @@ type TargetSpec struct {
 	JLinkDevice      string   `json:"jlink-device,omitempty"`
 	CodeModel        string   `json:"code-model,omitempty"`
 	RelocationModel  string   `json:"relocation-model,omitempty"`
+	WitPackage       string   `json:"wit-package,omitempty"`
+	WitWorld         string   `json:"wit-world,omitempty"`
 }
 
 // overrideProperties overrides all properties that are set in child into itself using reflection.

--- a/goenv/goenv.go
+++ b/goenv/goenv.go
@@ -159,6 +159,11 @@ func Get(name string) string {
 		}
 
 		return findWasmOpt()
+	case "WASMTOOLS":
+		if path := os.Getenv("WASMTOOLS"); path != "" {
+			return path
+		}
+		return "wasm-tools"
 	default:
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -1464,6 +1464,12 @@ func main() {
 		flag.StringVar(&outpath, "o", "", "output filename")
 	}
 
+	var witPackage, witWorld string
+	if command == "help" || command == "build" || command == "test" {
+		flag.StringVar(&witPackage, "wit-package", "", "wit package for wasm component embedding")
+		flag.StringVar(&witWorld, "wit-world", "", "wit world for wasm component embedding")
+	}
+
 	var testConfig compileopts.TestConfig
 	if command == "help" || command == "test" {
 		flag.BoolVar(&testConfig.CompileOnly, "c", false, "compile the test binary but do not run it")
@@ -1543,6 +1549,8 @@ func main() {
 		Monitor:         *monitor,
 		BaudRate:        *baudrate,
 		Timeout:         *timeout,
+		WitPackage:      witPackage,
+		WitWorld:        witWorld,
 	}
 	if *printCommands {
 		options.PrintCommands = printCommand

--- a/targets/wasip2.json
+++ b/targets/wasip2.json
@@ -22,5 +22,7 @@
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator":      "wasmtime --wasm component-model --dir={tmpDir}::/tmp {}"
+	"emulator": "wasmtime --wasm component-model --dir={tmpDir}::/tmp {}",
+	"wit-package": "{root}/lib/wasi-cli/wit/",
+	"wit-world": "wasi:cli/command"
 }


### PR DESCRIPTION
Leverage existing wasm-tools cli functionality to
produce wasm component binaries that are usable
immediately with runtimes like wasmtime.

New -wit-package and -wit-world options can be set to define which wit package and world should be
embedded using wasm-tools.

This primarily enables the use of tinygo test to
run existing test packages with -target=wasip2.
See the temporary makefile targets for examples:

    make tinygo-test-wasip2-wip
    make tinygo-test-wasip2-dev