### PR TITLE
test: gotestsum for cleaner summary

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -382,6 +382,14 @@ TEST_PACKAGES_WINDOWS := \
 	text/template/parse \
 	$(nil)
 
+TEST_PACKAGES_WASIP2_GAP := \
+	compress/lzw \
+	compress/zlib \
+	internal/profile \
+	math \
+	math/cmplx \
+	os
+
 # Report platforms on which each standard library package is known to pass tests
 jointmp := $(shell echo /tmp/join.$$$$)
 report-stdlib-tests-pass:
@@ -434,9 +442,27 @@ tinygo-test-wasi-fast:
 tinygo-test-wasip1-fast:
 	GOOS=wasip1 GOARCH=wasm $(TINYGO) test $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-test-wasip2-wip:
-	$(TINYGO) test -target wasip2 -x $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
+	$(TINYGO) test -target wasip2 -x -v $(TEST_PACKAGES_FAST) ./tests/runtime_wasi
 tinygo-test-wasip2-dev:
 	$(TINYGO) test -target wasip2 -wit-package $$(tinygo env TINYGOROOT)/lib/wasi-cli/wit/ -wit-world wasi:cli/command -x -work encoding/csv
+tinygo-test-wasip2-sum-slow:
+	TINYGO=$(TINYGO) \
+	TARGET=wasip2 \
+	TESTOPTS="-x -work" \
+	PACKAGES="$(TEST_PACKAGES_SLOW)" \
+	gotestsum --raw-command -- ./tools/tgtestjson.sh
+tinygo-test-wasip2-sum-fast:
+	TINYGO=$(TINYGO) \
+	TARGET=wasip2 \
+	TESTOPTS="-x -work" \
+	PACKAGES="$(TEST_PACKAGES_FAST)" \
+	gotestsum --raw-command -- ./tools/tgtestjson.sh
+tinygo-test-wasip2-sum-gap:
+	TINYGO=$(TINYGO) \
+	TARGET=wasip2 \
+	TESTOPTS="-x -work" \
+	PACKAGES="$(TEST_PACKAGES_WASIP2_GAP)" \
+	gotestsum --raw-command -- ./tools/tgtestjson.sh 
 tinygo-bench-wasi:
 	$(TINYGO) test -target wasi -bench . $(TEST_PACKAGES_FAST) $(TEST_PACKAGES_SLOW)
 tinygo-bench-wasi-fast:

--- a/tools/tgtestjson.sh
+++ b/tools/tgtestjson.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Run tests and convert output to json with go tool test2json.
+# This is a workaround for the lack of -json output in tinygo test.
+# Some variables must be set in the environment beforehand.
+# TODO: let's just add -json support to tinygo test.
+
+TINYGO="${TINYGO:-tinygo}"
+PACKAGES="${PACKAGES:-"./tests"}"
+TARGET="${TARGET:-wasip2}"
+TESTOPTS="${TESTOPTS:-"-x -work"}"
+
+go clean -testcache
+for pkg in $PACKAGES; do
+    # Example invocation with test2json in BigGo:
+    # go test -test.v=test2json ./$pkg 2>&1 | go tool test2json -p $pkg
+
+    # Uncomment to see resolved commands in output
+    # >&2 echo "${TINYGO} test -v -target $TARGET $TESTOPTS $pkg 2>&1 | go tool test2json -p $pkg"
+    "${TINYGO}" test -v -target $TARGET $TESTOPTS $pkg 2>&1 | go tool test2json -p $pkg
+
+done

--- a/tools/tgtestjson.sh
+++ b/tools/tgtestjson.sh
@@ -10,7 +10,7 @@ PACKAGES="${PACKAGES:-"./tests"}"
 TARGET="${TARGET:-wasip2}"
 TESTOPTS="${TESTOPTS:-"-x -work"}"
 
-go clean -testcache
+# go clean -testcache
 for pkg in $PACKAGES; do
     # Example invocation with test2json in BigGo:
     # go test -test.v=test2json ./$pkg 2>&1 | go tool test2json -p $pkg


### PR DESCRIPTION
gotestsum presents go test results in a prettier format. This is helpful to see an overview of status. Currently this uses a small shell script to manage the package names and pipes through go tool test2json. In a follow-up maybe we can can add -json to tinygo test instead.

There are some new temporary makefile targets to show usage and make it easy to run for now. "-fast" runs the TEST_PACKAGES_FAST list, "-gap" runs the known list of failures from that collection only.

  make tinygo-test-wasip2-sum-fast
  make tinygo-test-wasip2-sum-gap

Example:

```sh
❯ make tinygo-test-wasip2-sum-fast
TINYGO=/workspaces/dc-wasm-go/bin/tinygo \
TARGET=wasip2 \
TESTOPTS="-x -work" \
PACKAGES="compress/lzw compress/zlib container/heap container/list container/ring crypto/des crypto/md5 crypto/rc4 crypto/sha1 crypto/sha256 crypto/sha512 debug/macho embed/internal/embedtest encoding encoding/ascii85 encoding/base32 encoding/base64 encoding/csv encoding/hex go/scanner hash hash/adler32 hash/crc64 hash/fnv html internal/itoa internal/profile math math/cmplx net/http/internal/ascii net/mail os path reflect sync testing testing/iotest text/scanner unicode unicode/utf16 unicode/utf8  crypto/internal/nistec/fiat" \
gotestsum --raw-command -- ./tools/tgtestjson.sh 
✖  compress/lzw
✖  compress/zlib
✓  container/heap
✓  container/list
✓  container/ring
✓  crypto/des
✓  crypto/md5
✓  crypto/rc4
✓  crypto/sha1
✓  crypto/sha256
✓  crypto/sha512
✓  debug/macho
✓  embed/internal/embedtest
∅  encoding
✓  encoding/ascii85
✓  encoding/base32
✓  encoding/base64
✓  encoding/csv
✓  encoding/hex
✓  go/scanner
✓  hash
✓  hash/adler32
✓  hash/crc64
✓  hash/fnv
✓  html
✓  internal/itoa
✖  internal/profile
✖  math
✖  math/cmplx
✓  net/http/internal/ascii
✓  net/mail
✖  os
✓  path
✓  reflect
✓  sync
✓  testing
✓  testing/iotest
✓  text/scanner
✓  unicode
✓  unicode/utf16
✓  unicode/utf8
∅  crypto/internal/nistec/fiat
```