### PR TITLE
compiler: refine wasm types proposal

### DIFF
--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -360,14 +360,14 @@ func (c *compilerContext) checkWasmImport(f *ssa.Function, pragma string) {
 		c.addError(f.Signature.Results().At(1).Pos(), fmt.Sprintf("%s: too many return values", pragma))
 	} else if f.Signature.Results().Len() == 1 {
 		result := f.Signature.Results().At(0)
-		if !isValidWasmType(result.Type(), true, false) {
+		if !isValidWasmType(result.Type(), siteResult) {
 			c.addError(result.Pos(), fmt.Sprintf("%s: unsupported result type %s", pragma, result.Type().String()))
 		}
 	}
 	for _, param := range f.Params {
 		// Check whether the type is allowed.
 		// Only a very limited number of types can be mapped to WebAssembly.
-		if !isValidWasmType(param.Type(), false, false) {
+		if !isValidWasmType(param.Type(), siteParam) {
 			c.addError(param.Pos(), fmt.Sprintf("%s: unsupported parameter type %s", pragma, param.Type().String()))
 		}
 	}
@@ -380,7 +380,7 @@ func (c *compilerContext) checkWasmImport(f *ssa.Function, pragma string) {
 //
 // This previously reflected the additional restrictions documented here:
 // https://github.com/golang/go/issues/59149
-func isValidWasmType(typ types.Type, isResult, isPointerOrField bool) bool {
+func isValidWasmType(typ types.Type, site wasmSite) bool {
 	switch typ := typ.Underlying().(type) {
 	case *types.Basic:
 		switch typ.Kind() {
@@ -393,25 +393,34 @@ func isValidWasmType(typ types.Type, isResult, isPointerOrField bool) bool {
 		case types.Uintptr, types.UnsafePointer:
 			return true
 		case types.String:
-			return !isResult // string flattens to two values, so disallowed as a result
+			// string flattens to two values, so disallowed as a result
+			return site == siteParam || site == siteIndirect
 		}
 	case *types.Array:
-		return isPointerOrField && isValidWasmType(typ.Elem(), false, true)
+		return site == siteIndirect && isValidWasmType(typ.Elem(), siteIndirect)
 	case *types.Struct:
-		if !isPointerOrField {
+		if site != siteIndirect {
 			return false
 		}
 		for i := 0; i < typ.NumFields(); i++ {
-			if !isValidWasmType(typ.Field(i).Type(), false, true) {
+			if !isValidWasmType(typ.Field(i).Type(), siteIndirect) {
 				return false
 			}
 		}
 		return true
 	case *types.Pointer:
-		return isValidWasmType(typ.Elem(), false, true)
+		return isValidWasmType(typ.Elem(), siteIndirect)
 	}
 	return false
 }
+
+type wasmSite int
+
+const (
+	siteParam wasmSite = iota
+	siteResult
+	siteIndirect // pointer or field
+)
 
 // getParams returns the function parameters, including the receiver at the
 // start. This is an alternative to the Params member of *ssa.Function, which is

--- a/compiler/symbol.go
+++ b/compiler/symbol.go
@@ -393,7 +393,7 @@ func isValidWasmType(typ types.Type, isPointerOrField bool) bool {
 		case types.Uintptr, types.UnsafePointer:
 			return true
 		case types.String:
-			return isPointerOrField
+			return true
 		}
 	case *types.Array:
 		return isPointerOrField && isValidWasmType(typ.Elem(), true)

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -22,7 +22,7 @@ type S struct {
 }
 
 //go:wasmimport modulename validparam
-func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g *int32, h *S)
+func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g string, h *int32, i *S)
 
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type [4]uint32
 // ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type []byte

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -33,42 +33,45 @@ func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintpt
 //go:wasmimport modulename invalidparam
 func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func())
 
-//go:wasmimport modulename validreturn1
-func validreturn1() int32
+//go:wasmimport modulename validreturn_int32
+func validreturn_int32() int32
 
-//go:wasmimport modulename validreturn2
-func validreturn2() int
+//go:wasmimport modulename validreturn_int
+func validreturn_int() int
 
-//go:wasmimport modulename validreturn3
-func validreturn3() *int32
+//go:wasmimport modulename validreturn_ptr_int32
+func validreturn_ptr_int32() *int32
 
-//go:wasmimport modulename validreturn4
-func validreturn4() *S
+//go:wasmimport modulename validreturn_ptr_string
+func validreturn_ptr_string() *string
 
-//go:wasmimport modulename validreturn5
-func validreturn5() unsafe.Pointer
+//go:wasmimport modulename validreturn_ptr_struct
+func validreturn_ptr_struct() *S
+
+//go:wasmimport modulename validreturn_unsafe_pointer
+func validreturn_unsafe_pointer() unsafe.Pointer
 
 // ERROR: //go:wasmimport modulename manyreturns: too many return values
 //
 //go:wasmimport modulename manyreturns
 func manyreturns() (int32, int32)
 
-// ERROR: //go:wasmimport modulename invalidreturn1: unsupported result type func()
+// ERROR: //go:wasmimport modulename invalidreturn_func: unsupported result type func()
 //
-//go:wasmimport modulename invalidreturn1
-func invalidreturn1() func()
+//go:wasmimport modulename invalidreturn_func
+func invalidreturn_func() func()
 
-// ERROR: //go:wasmimport modulename invalidreturn2: unsupported result type []byte
+// ERROR: //go:wasmimport modulename invalidreturn_slice_byte: unsupported result type []byte
 //
-//go:wasmimport modulename invalidreturn2
-func invalidreturn2() []byte
+//go:wasmimport modulename invalidreturn_slice_byte
+func invalidreturn_slice_byte() []byte
 
-// ERROR: //go:wasmimport modulename invalidreturn3: unsupported result type chan int
+// ERROR: //go:wasmimport modulename invalidreturn_chan_int: unsupported result type chan int
 //
-//go:wasmimport modulename invalidreturn3
-func invalidreturn3() chan int
+//go:wasmimport modulename invalidreturn_chan_int
+func invalidreturn_chan_int() chan int
 
-// ERROR: //go:wasmimport modulename invalidreturn4: unsupported result type string
+// ERROR: //go:wasmimport modulename invalidreturn_string: unsupported result type string
 //
-//go:wasmimport modulename invalidreturn4
-func invalidreturn4() string
+//go:wasmimport modulename invalidreturn_string
+func invalidreturn_string() string

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -13,8 +13,25 @@ func implementation() {
 
 type Uint uint32
 
+type S struct {
+	a [4]uint32
+	b uintptr
+	c int
+	d float32
+	e float64
+}
+
 //go:wasmimport modulename validparam
-func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint)
+func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintptr, g *int32, h *S)
+
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type [4]uint32
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type []byte
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type struct{a int}
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type chan struct{}
+// ERROR: //go:wasmimport modulename invalidparam: unsupported parameter type func()
+//
+//go:wasmimport modulename invalidparam
+func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func())
 
 //go:wasmimport modulename validreturn
 func validreturn() int32
@@ -28,3 +45,8 @@ func manyreturns() (int32, int32)
 //
 //go:wasmimport modulename invalidreturn
 func invalidreturn() int
+
+// ERROR: //go:wasmimport modulename invalidUnsafePointerReturn: unsupported result type unsafe.Pointer
+//
+//go:wasmimport modulename invalidUnsafePointerReturn
+func invalidUnsafePointerReturn() unsafe.Pointer

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -33,20 +33,37 @@ func validparam(a int32, b uint64, c float64, d unsafe.Pointer, e Uint, f uintpt
 //go:wasmimport modulename invalidparam
 func invalidparam(a [4]uint32, b []byte, c struct{ a int }, d chan struct{}, e func())
 
-//go:wasmimport modulename validreturn
-func validreturn() int32
+//go:wasmimport modulename validreturn1
+func validreturn1() int32
+
+//go:wasmimport modulename validreturn2
+func validreturn2() int
+
+//go:wasmimport modulename validreturn3
+func validreturn3() *int32
+
+//go:wasmimport modulename validreturn4
+func validreturn4() *S
+
+//go:wasmimport modulename validreturn5
+func validreturn5() unsafe.Pointer
 
 // ERROR: //go:wasmimport modulename manyreturns: too many return values
 //
 //go:wasmimport modulename manyreturns
 func manyreturns() (int32, int32)
 
-// ERROR: //go:wasmimport modulename invalidreturn: unsupported result type int
+// ERROR: //go:wasmimport modulename invalidreturn1: unsupported result type func()
 //
-//go:wasmimport modulename invalidreturn
-func invalidreturn() int
+//go:wasmimport modulename invalidreturn1
+func invalidreturn1() func()
 
-// ERROR: //go:wasmimport modulename invalidUnsafePointerReturn: unsupported result type unsafe.Pointer
+// ERROR: //go:wasmimport modulename invalidreturn2: unsupported result type []byte
 //
-//go:wasmimport modulename invalidUnsafePointerReturn
-func invalidUnsafePointerReturn() unsafe.Pointer
+//go:wasmimport modulename invalidreturn2
+func invalidreturn2() []byte
+
+// ERROR: //go:wasmimport modulename invalidreturn3: unsupported result type chan int
+//
+//go:wasmimport modulename invalidreturn3
+func invalidreturn3() chan int

--- a/compiler/testdata/errors.go
+++ b/compiler/testdata/errors.go
@@ -67,3 +67,8 @@ func invalidreturn2() []byte
 //
 //go:wasmimport modulename invalidreturn3
 func invalidreturn3() chan int
+
+// ERROR: //go:wasmimport modulename invalidreturn4: unsupported result type string
+//
+//go:wasmimport modulename invalidreturn4
+func invalidreturn4() string


### PR DESCRIPTION
This PR adds tests for the relaxed wasm param and result type restrictions, and re-adds `string` as an allowed param type.

See https://github.com/golang/go/issues/66984 for additional context.